### PR TITLE
Use WasmLoader class in lib and dist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Incapsulate methods and callback storage in 'WasmLoader' class
+
 ## [0.3.0][] - 2023-08-12
 
 - Support in-place callbacks

--- a/dist/loader.mjs
+++ b/dist/loader.mjs
@@ -1,50 +1,63 @@
-const CALLBACK_LEN = 'Callback'.length;
-const calls = new Map();
+const CALLBACK_POSTFIX_LEN = 'Callback'.length;
 
-const prepareImports = (byteCode) => {
-  const imports = WebAssembly.Module.imports(byteCode);
-  const expected = {};
-  for (const entry of imports) {
-    if (entry.kind !== 'function') continue;
-    let module = expected[entry.module];
-    if (!module) module = expected[entry.module] = {};
-    module[entry.name] = (...args) => {
-      const name = entry.name.slice(0, -CALLBACK_LEN);
-      const callbacks = calls.get(name);
-      if (!callbacks) return;
-      const callback = callbacks.shift();
-      if (!callback) return;
-      callback(...args);
-    };
+class WasmLoader {
+  #calls;
+
+  constructor(storage = null) {
+    this.#calls = storage ?? new Map();
   }
-  return expected;
-};
 
-const load = async (fileName, importObject = {}) => {
-  const response = await fetch(fileName);
-  const buffer = await response.arrayBuffer();
-  const compiled = await WebAssembly.compile(buffer);
-  const expected = prepareImports(compiled);
-  const imports = { ...importObject, ...expected };
-  const instance = await WebAssembly.instantiate(compiled, imports);
-  const exports = {};
-  for (const [name, fn] of Object.entries(instance.exports)) {
-    if (typeof fn !== 'function') {
-      exports[name] = fn;
-      continue;
+  _prepareImports(byteCode) {
+    const imports = WebAssembly.Module.imports(byteCode);
+    const expected = {};
+    for (const entry of imports) {
+      if (entry.kind !== 'function') continue;
+      let module = expected[entry.module];
+      if (!module) module = expected[entry.module] = {};
+      module[entry.name] = (...args) => {
+        const name = entry.name.slice(0, -CALLBACK_POSTFIX_LEN);
+        const callbacks = this.#calls.get(name);
+        if (!callbacks) return;
+        const callback = callbacks.shift();
+        if (!callback) return;
+        callback(...args);
+      };
     }
-    exports[name] = (...args) => {
-      if (typeof args.at(-1) !== 'function') return fn(...args);
-      let callbacks = calls.get(name);
-      if (!callbacks) {
-        callbacks = [];
-        calls.set(name, callbacks);
-      }
-      callbacks.push(args.pop());
-      return fn(...args);
-    };
+    return expected;
   }
-  return { instance: { exports }, module: compiled };
-};
+
+  _prepareExports(instance) {
+    const exports = {};
+    for (const [name, exported] of Object.entries(instance.exports)) {
+      if (typeof exported !== 'function') {
+        exports[name] = exported;
+        continue;
+      }
+      exports[name] = (...args) => {
+        if (typeof args.at(-1) !== 'function') return exported(...args);
+        const callbacks = this.#calls.get(name) || [];
+        callbacks.push(args.pop());
+        this.#calls.set(name, callbacks);
+        return exported(...args);
+      };
+    }
+    return exports;
+  }
+
+  async load(fileName, importObject = {}) {
+    const response = await fetch(fileName);
+    const buffer = await response.arrayBuffer();
+    const compiled = await WebAssembly.compile(buffer);
+    const expected = this._prepareImports(compiled);
+    const imports = { ...importObject, ...expected };
+    const instance = await WebAssembly.instantiate(compiled, imports);
+    const exports = this._prepareExports(instance);
+    return { instance: { exports }, module: compiled };
+  }
+}
+
+const loader = new WasmLoader();
+
+const load = (...args) => loader.load(...args);
 
 export { load };

--- a/lib/node.js
+++ b/lib/node.js
@@ -2,52 +2,65 @@
 
 const fsp = require('node:fs').promises;
 
-const CALLBACK_LEN = 'Callback'.length;
-const calls = new Map();
+const CALLBACK_POSTFIX_LEN = 'Callback'.length;
 
-const prepareImports = (byteCode) => {
-  const imports = WebAssembly.Module.imports(byteCode);
-  const expected = {};
-  for (const entry of imports) {
-    if (entry.kind !== 'function') continue;
-    let module = expected[entry.module];
-    if (!module) module = expected[entry.module] = {};
-    module[entry.name] = (...args) => {
-      const name = entry.name.slice(0, -CALLBACK_LEN);
-      const callbacks = calls.get(name);
-      if (!callbacks) return;
-      const callback = callbacks.shift();
-      if (!callback) return;
-      callback(...args);
-    };
+class WasmLoader {
+  #calls;
+
+  constructor(storage = null) {
+    this.#calls = storage ?? new Map();
   }
-  return expected;
-};
 
-const load = async (fileName, importObject = {}) => {
-  const buffer = await fsp.readFile(fileName);
-  const compiled = await WebAssembly.compile(buffer);
-  const expected = prepareImports(compiled);
-  const imports = { ...importObject, ...expected };
-  const instance = await WebAssembly.instantiate(compiled, imports);
-  const exports = {};
-  for (const [name, fn] of Object.entries(instance.exports)) {
-    if (typeof fn !== 'function') {
-      exports[name] = fn;
-      continue;
+  _prepareImports(byteCode) {
+    const imports = WebAssembly.Module.imports(byteCode);
+    const expected = {};
+    for (const entry of imports) {
+      if (entry.kind !== 'function') continue;
+      let module = expected[entry.module];
+      if (!module) module = expected[entry.module] = {};
+      module[entry.name] = (...args) => {
+        const name = entry.name.slice(0, -CALLBACK_POSTFIX_LEN);
+        const callbacks = this.#calls.get(name);
+        if (!callbacks) return;
+        const callback = callbacks.shift();
+        if (!callback) return;
+        callback(...args);
+      };
     }
-    exports[name] = (...args) => {
-      if (typeof args.at(-1) !== 'function') return fn(...args);
-      let callbacks = calls.get(name);
-      if (!callbacks) {
-        callbacks = [];
-        calls.set(name, callbacks);
-      }
-      callbacks.push(args.pop());
-      return fn(...args);
-    };
+    return expected;
   }
-  return { instance: { exports }, module: compiled };
-};
+
+  _prepareExports(instance) {
+    const exports = {};
+    for (const [name, exported] of Object.entries(instance.exports)) {
+      if (typeof exported !== 'function') {
+        exports[name] = exported;
+        continue;
+      }
+      exports[name] = (...args) => {
+        if (typeof args.at(-1) !== 'function') return exported(...args);
+        const callbacks = this.#calls.get(name) || [];
+        callbacks.push(args.pop());
+        this.#calls.set(name, callbacks);
+        return exported(...args);
+      };
+    }
+    return exports;
+  }
+
+  async load(fileName, importObject = {}) {
+    const buffer = await fsp.readFile(fileName);
+    const compiled = await WebAssembly.compile(buffer);
+    const expected = this._prepareImports(compiled);
+    const imports = { ...importObject, ...expected };
+    const instance = await WebAssembly.instantiate(compiled, imports);
+    const exports = this._prepareExports(instance);
+    return { instance: { exports }, module: compiled };
+  }
+}
+
+const loader = new WasmLoader();
+
+const load = (...args) => loader.load(...args);
 
 module.exports = { load };


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features; not applicable
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings: not needed

Ideas:
- Just to follow the node's  WASM spirit, suggesting 'gentle' class-based approach here, basically just putting the methods together with the 'calls' storage that we are mutating into a separarate scope called 'WasmLaoder';

API:
same for now, exposing the 'load' function;