### PR TITLE
WIP: Universal test set for all languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [Unreleased][unreleased]
 
-- Incapsulate methods and callback storage in 'WasmLoader' class
 - Shortcut 'module.instance.exports.method' to 'module.method' for convenience
 
 ## [0.3.0][] - 2023-08-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Incapsulate methods and callback storage in 'WasmLoader' class
+- Shortcut 'module.instance.exports.method' to 'module.method' for convenience
 
 ## [0.3.0][] - 2023-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Incapsulate methods and callback storage in 'WasmLoader' class
+
 ## [0.3.0][] - 2023-08-12
 
 - Support in-place callbacks

--- a/dist/loader.mjs
+++ b/dist/loader.mjs
@@ -1,50 +1,73 @@
-const CALLBACK_LEN = 'Callback'.length;
-const calls = new Map();
+const CALLBACK_POSTFIX_LEN = 'Callback'.length;
 
-const prepareImports = (byteCode) => {
-  const imports = WebAssembly.Module.imports(byteCode);
-  const expected = {};
-  for (const entry of imports) {
-    if (entry.kind !== 'function') continue;
-    let module = expected[entry.module];
-    if (!module) module = expected[entry.module] = {};
-    module[entry.name] = (...args) => {
-      const name = entry.name.slice(0, -CALLBACK_LEN);
-      const callbacks = calls.get(name);
-      if (!callbacks) return;
-      const callback = callbacks.shift();
-      if (!callback) return;
-      callback(...args);
-    };
+const buildModule = (exports, compiled) => {
+  const module = { instance: { exports }, module: compiled };
+  for (const propName of Object.getOwnPropertyNames(exports)) {
+    if (['instance', 'module'].includes(propName)) continue;
+    const descriptor = Object.getOwnPropertyDescriptor(exports, propName);
+    Object.defineProperty(module, propName, descriptor);
   }
-  return expected;
+  return module;
 };
 
-const load = async (fileName, importObject = {}) => {
-  const response = await fetch(fileName);
-  const buffer = await response.arrayBuffer();
-  const compiled = await WebAssembly.compile(buffer);
-  const expected = prepareImports(compiled);
-  const imports = { ...importObject, ...expected };
-  const instance = await WebAssembly.instantiate(compiled, imports);
-  const exports = {};
-  for (const [name, fn] of Object.entries(instance.exports)) {
-    if (typeof fn !== 'function') {
-      exports[name] = fn;
-      continue;
+class WasmLoader {
+  #calls;
+
+  constructor(storage = null) {
+    this.#calls = storage ?? new Map();
+  }
+
+  _prepareImports(byteCode) {
+    const imports = WebAssembly.Module.imports(byteCode);
+    const expected = {};
+    for (const entry of imports) {
+      if (entry.kind !== 'function') continue;
+      let module = expected[entry.module];
+      if (!module) module = expected[entry.module] = {};
+      module[entry.name] = (...args) => {
+        const name = entry.name.slice(0, -CALLBACK_POSTFIX_LEN);
+        const callbacks = this.#calls.get(name);
+        if (!callbacks) return;
+        const callback = callbacks.shift();
+        if (!callback) return;
+        callback(...args);
+      };
     }
-    exports[name] = (...args) => {
-      if (typeof args.at(-1) !== 'function') return fn(...args);
-      let callbacks = calls.get(name);
-      if (!callbacks) {
-        callbacks = [];
-        calls.set(name, callbacks);
-      }
-      callbacks.push(args.pop());
-      return fn(...args);
-    };
+    return expected;
   }
-  return { instance: { exports }, module: compiled };
-};
+
+  _prepareExports(instance) {
+    const exports = {};
+    for (const [name, exported] of Object.entries(instance.exports)) {
+      if (typeof exported !== 'function') {
+        exports[name] = exported;
+        continue;
+      }
+      exports[name] = (...args) => {
+        if (typeof args.at(-1) !== 'function') return exported(...args);
+        const callbacks = this.#calls.get(name) || [];
+        callbacks.push(args.pop());
+        this.#calls.set(name, callbacks);
+        return exported(...args);
+      };
+    }
+    return exports;
+  }
+
+  async load(fileName, importObject = {}) {
+    const response = await fetch(fileName);
+    const buffer = await response.arrayBuffer();
+    const compiled = await WebAssembly.compile(buffer);
+    const expected = this._prepareImports(compiled);
+    const imports = { ...importObject, ...expected };
+    const instance = await WebAssembly.instantiate(compiled, imports);
+    const exports = this._prepareExports(instance);
+    return buildModule(exports, compiled);
+  }
+}
+
+const loader = new WasmLoader();
+
+const load = (...args) => loader.load(...args);
 
 export { load };

--- a/dist/loader.mjs
+++ b/dist/loader.mjs
@@ -2,12 +2,11 @@ const CALLBACK_POSTFIX_LEN = 'Callback'.length;
 
 const buildModule = (exports, compiled) => {
   const module = { instance: { exports }, module: compiled };
-  for (const propName of Object.getOwnPropertyNames(exports)) {
-    if (['instance', 'module'].includes(propName)) continue;
-    const descriptor = Object.getOwnPropertyDescriptor(exports, propName);
-    Object.defineProperty(module, propName, descriptor);
-  }
-  return module;
+  return new Proxy(module, {
+    get(module, prop) {
+      return prop in module ? module[prop] : exports[prop];
+    },
+  });
 };
 
 class WasmLoader {

--- a/dist/loader.mjs
+++ b/dist/loader.mjs
@@ -1,4 +1,5 @@
-const CALLBACK_POSTFIX_LEN = 'Callback'.length;
+const CALLBACK_LEN = 'Callback'.length;
+const calls = new Map();
 
 const buildModule = (exports, compiled) => {
   const module = { instance: { exports }, module: compiled };
@@ -9,64 +10,50 @@ const buildModule = (exports, compiled) => {
   });
 };
 
-class WasmLoader {
-  #calls;
-
-  constructor(storage = null) {
-    this.#calls = storage ?? new Map();
+const prepareImports = (byteCode) => {
+  const imports = WebAssembly.Module.imports(byteCode);
+  const expected = {};
+  for (const entry of imports) {
+    if (entry.kind !== 'function') continue;
+    let module = expected[entry.module];
+    if (!module) module = expected[entry.module] = {};
+    module[entry.name] = (...args) => {
+      const name = entry.name.slice(0, -CALLBACK_LEN);
+      const callbacks = calls.get(name);
+      if (!callbacks) return;
+      const callback = callbacks.shift();
+      if (!callback) return;
+      callback(...args);
+    };
   }
+  return expected;
+};
 
-  _prepareImports(byteCode) {
-    const imports = WebAssembly.Module.imports(byteCode);
-    const expected = {};
-    for (const entry of imports) {
-      if (entry.kind !== 'function') continue;
-      let module = expected[entry.module];
-      if (!module) module = expected[entry.module] = {};
-      module[entry.name] = (...args) => {
-        const name = entry.name.slice(0, -CALLBACK_POSTFIX_LEN);
-        const callbacks = this.#calls.get(name);
-        if (!callbacks) return;
-        const callback = callbacks.shift();
-        if (!callback) return;
-        callback(...args);
-      };
+const load = async (fileName, importObject = {}) => {
+  const response = await fetch(fileName);
+  const buffer = await response.arrayBuffer();
+  const compiled = await WebAssembly.compile(buffer);
+  const expected = prepareImports(compiled);
+  const imports = { ...importObject, ...expected };
+  const instance = await WebAssembly.instantiate(compiled, imports);
+  const exports = {};
+  for (const [name, fn] of Object.entries(instance.exports)) {
+    if (typeof fn !== 'function') {
+      exports[name] = fn;
+      continue;
     }
-    return expected;
-  }
-
-  _prepareExports(instance) {
-    const exports = {};
-    for (const [name, exported] of Object.entries(instance.exports)) {
-      if (typeof exported !== 'function') {
-        exports[name] = exported;
-        continue;
+    exports[name] = (...args) => {
+      if (typeof args.at(-1) !== 'function') return fn(...args);
+      let callbacks = calls.get(name);
+      if (!callbacks) {
+        callbacks = [];
+        calls.set(name, callbacks);
       }
-      exports[name] = (...args) => {
-        if (typeof args.at(-1) !== 'function') return exported(...args);
-        const callbacks = this.#calls.get(name) || [];
-        callbacks.push(args.pop());
-        this.#calls.set(name, callbacks);
-        return exported(...args);
-      };
-    }
-    return exports;
+      callbacks.push(args.pop());
+      return fn(...args);
+    };
   }
-
-  async load(fileName, importObject = {}) {
-    const response = await fetch(fileName);
-    const buffer = await response.arrayBuffer();
-    const compiled = await WebAssembly.compile(buffer);
-    const expected = this._prepareImports(compiled);
-    const imports = { ...importObject, ...expected };
-    const instance = await WebAssembly.instantiate(compiled, imports);
-    const exports = this._prepareExports(instance);
-    return buildModule(exports, compiled);
-  }
-}
-
-const loader = new WasmLoader();
-
-const load = (...args) => loader.load(...args);
+  return buildModule(exports, compiled);
+};
 
 export { load };

--- a/lib/node.js
+++ b/lib/node.js
@@ -61,6 +61,6 @@ class WasmLoader {
 
 const loader = new WasmLoader();
 
-const load = async (...args) => loader.load(...args);
+const load = (...args) => loader.load(...args);
 
 module.exports = { load };

--- a/lib/node.js
+++ b/lib/node.js
@@ -6,12 +6,11 @@ const CALLBACK_POSTFIX_LEN = 'Callback'.length;
 
 const buildModule = (exports, compiled) => {
   const module = { instance: { exports }, module: compiled };
-  for (const propName of Object.getOwnPropertyNames(exports)) {
-    if (['instance', 'module'].includes(propName)) continue;
-    const descriptor = Object.getOwnPropertyDescriptor(exports, propName);
-    Object.defineProperty(module, propName, descriptor);
-  }
-  return module;
+  return new Proxy(module, {
+    get(module, prop) {
+      return prop in module ? module[prop] : exports[prop];
+    },
+  });
 };
 
 class WasmLoader {

--- a/lib/node.js
+++ b/lib/node.js
@@ -4,6 +4,16 @@ const fsp = require('node:fs').promises;
 
 const CALLBACK_POSTFIX_LEN = 'Callback'.length;
 
+const buildModule = (exports, compiled) => {
+  const module = { instance: { exports }, module: compiled };
+  for (const propName of Object.getOwnPropertyNames(exports)) {
+    if (['instance', 'module'].includes(propName)) continue;
+    const descriptor = Object.getOwnPropertyDescriptor(exports, propName);
+    Object.defineProperty(module, propName, descriptor);
+  }
+  return module;
+};
+
 class WasmLoader {
   #calls;
 
@@ -55,7 +65,7 @@ class WasmLoader {
     const imports = { ...importObject, ...expected };
     const instance = await WebAssembly.instantiate(compiled, imports);
     const exports = this._prepareExports(instance);
-    return { instance: { exports }, module: compiled };
+    return buildModule(exports, compiled);
   }
 }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -2,7 +2,8 @@
 
 const fsp = require('node:fs').promises;
 
-const CALLBACK_POSTFIX_LEN = 'Callback'.length;
+const CALLBACK_LEN = 'Callback'.length;
+const calls = new Map();
 
 const buildModule = (exports, compiled) => {
   const module = { instance: { exports }, module: compiled };
@@ -13,63 +14,49 @@ const buildModule = (exports, compiled) => {
   });
 };
 
-class WasmLoader {
-  #calls;
-
-  constructor(storage = null) {
-    this.#calls = storage ?? new Map();
+const prepareImports = (byteCode) => {
+  const imports = WebAssembly.Module.imports(byteCode);
+  const expected = {};
+  for (const entry of imports) {
+    if (entry.kind !== 'function') continue;
+    let module = expected[entry.module];
+    if (!module) module = expected[entry.module] = {};
+    module[entry.name] = (...args) => {
+      const name = entry.name.slice(0, -CALLBACK_LEN);
+      const callbacks = calls.get(name);
+      if (!callbacks) return;
+      const callback = callbacks.shift();
+      if (!callback) return;
+      callback(...args);
+    };
   }
+  return expected;
+};
 
-  _prepareImports(byteCode) {
-    const imports = WebAssembly.Module.imports(byteCode);
-    const expected = {};
-    for (const entry of imports) {
-      if (entry.kind !== 'function') continue;
-      let module = expected[entry.module];
-      if (!module) module = expected[entry.module] = {};
-      module[entry.name] = (...args) => {
-        const name = entry.name.slice(0, -CALLBACK_POSTFIX_LEN);
-        const callbacks = this.#calls.get(name);
-        if (!callbacks) return;
-        const callback = callbacks.shift();
-        if (!callback) return;
-        callback(...args);
-      };
+const load = async (fileName, importObject = {}) => {
+  const buffer = await fsp.readFile(fileName);
+  const compiled = await WebAssembly.compile(buffer);
+  const expected = prepareImports(compiled);
+  const imports = { ...importObject, ...expected };
+  const instance = await WebAssembly.instantiate(compiled, imports);
+  const exports = {};
+  for (const [name, fn] of Object.entries(instance.exports)) {
+    if (typeof fn !== 'function') {
+      exports[name] = fn;
+      continue;
     }
-    return expected;
-  }
-
-  _prepareExports(instance) {
-    const exports = {};
-    for (const [name, exported] of Object.entries(instance.exports)) {
-      if (typeof exported !== 'function') {
-        exports[name] = exported;
-        continue;
+    exports[name] = (...args) => {
+      if (typeof args.at(-1) !== 'function') return fn(...args);
+      let callbacks = calls.get(name);
+      if (!callbacks) {
+        callbacks = [];
+        calls.set(name, callbacks);
       }
-      exports[name] = (...args) => {
-        if (typeof args.at(-1) !== 'function') return exported(...args);
-        const callbacks = this.#calls.get(name) || [];
-        callbacks.push(args.pop());
-        this.#calls.set(name, callbacks);
-        return exported(...args);
-      };
-    }
-    return exports;
+      callbacks.push(args.pop());
+      return fn(...args);
+    };
   }
-
-  async load(fileName, importObject = {}) {
-    const buffer = await fsp.readFile(fileName);
-    const compiled = await WebAssembly.compile(buffer);
-    const expected = this._prepareImports(compiled);
-    const imports = { ...importObject, ...expected };
-    const instance = await WebAssembly.instantiate(compiled, imports);
-    const exports = this._prepareExports(instance);
-    return buildModule(exports, compiled);
-  }
-}
-
-const loader = new WasmLoader();
-
-const load = (...args) => loader.load(...args);
+  return buildModule(exports, compiled);
+};
 
 module.exports = { load };

--- a/lib/node.js
+++ b/lib/node.js
@@ -2,52 +2,65 @@
 
 const fsp = require('node:fs').promises;
 
-const CALLBACK_LEN = 'Callback'.length;
-const calls = new Map();
+const CALLBACK_POSTFIX_LEN = 'Callback'.length;
 
-const prepareImports = (byteCode) => {
-  const imports = WebAssembly.Module.imports(byteCode);
-  const expected = {};
-  for (const entry of imports) {
-    if (entry.kind !== 'function') continue;
-    let module = expected[entry.module];
-    if (!module) module = expected[entry.module] = {};
-    module[entry.name] = (...args) => {
-      const name = entry.name.slice(0, -CALLBACK_LEN);
-      const callbacks = calls.get(name);
-      if (!callbacks) return;
-      const callback = callbacks.shift();
-      if (!callback) return;
-      callback(...args);
-    };
+class WasmLoader {
+  #calls;
+
+  constructor(storage = null) {
+    this.#calls = storage ?? new Map();
   }
-  return expected;
-};
 
-const load = async (fileName, importObject = {}) => {
-  const buffer = await fsp.readFile(fileName);
-  const compiled = await WebAssembly.compile(buffer);
-  const expected = prepareImports(compiled);
-  const imports = { ...importObject, ...expected };
-  const instance = await WebAssembly.instantiate(compiled, imports);
-  const exports = {};
-  for (const [name, fn] of Object.entries(instance.exports)) {
-    if (typeof fn !== 'function') {
-      exports[name] = fn;
-      continue;
+  _prepareImports(byteCode) {
+    const imports = WebAssembly.Module.imports(byteCode);
+    const expected = {};
+    for (const entry of imports) {
+      if (entry.kind !== 'function') continue;
+      let module = expected[entry.module];
+      if (!module) module = expected[entry.module] = {};
+      module[entry.name] = (...args) => {
+        const name = entry.name.slice(0, -CALLBACK_POSTFIX_LEN);
+        const callbacks = this.#calls.get(name);
+        if (!callbacks) return;
+        const callback = callbacks.shift();
+        if (!callback) return;
+        callback(...args);
+      };
     }
-    exports[name] = (...args) => {
-      if (typeof args.at(-1) !== 'function') return fn(...args);
-      let callbacks = calls.get(name);
-      if (!callbacks) {
-        callbacks = [];
-        calls.set(name, callbacks);
-      }
-      callbacks.push(args.pop());
-      return fn(...args);
-    };
+    return expected;
   }
-  return { instance: { exports }, module: compiled };
-};
+
+  _prepareExports(instance) {
+    const exports = {};
+    for (const [name, exported] of Object.entries(instance.exports)) {
+      if (typeof exported !== 'function') {
+        exports[name] = exported;
+        continue;
+      }
+      exports[name] = (...args) => {
+        if (typeof args.at(-1) !== 'function') return exported(...args);
+        const callbacks = this.#calls.get(name) || [];
+        callbacks.push(args.pop());
+        this.#calls.set(name, callbacks);
+        return exported(...args);
+      };
+    }
+    return exports;
+  }
+
+  async load(fileName, importObject = {}) {
+    const buffer = await fsp.readFile(fileName);
+    const compiled = await WebAssembly.compile(buffer);
+    const expected = this._prepareImports(compiled);
+    const imports = { ...importObject, ...expected };
+    const instance = await WebAssembly.instantiate(compiled, imports);
+    const exports = this._prepareExports(instance);
+    return { instance: { exports }, module: compiled };
+  }
+}
+
+const loader = new WasmLoader();
+
+const load = async (...args) => loader.load(...args);
 
 module.exports = { load };

--- a/test/node.js
+++ b/test/node.js
@@ -28,6 +28,13 @@ metatests.test('Rust WASM (node): wasm-pack', async (test) => {
     test.strictEqual(res, 10);
   });
 
+  const strictEq = (wanted) => (got) => test.strictEqual(got, wanted);
+  example.add(10, 5, strictEq(15));
+  example.add(-2, 7, strictEq(5));
+  example.add(65535, 1, strictEq(2 ** 16));
+  example.sub(10, 10, strictEq(0));
+  example.sub(23, 1000_000, strictEq(-999_977));
+
   test.end();
 });
 
@@ -53,6 +60,13 @@ metatests.test('WAT WASM (node): wabt/wat2wasm', async (test) => {
   example.instance.exports.sub(20, 10, (res) => {
     test.strictEqual(res, 10);
   });
+
+  const strictEq = (wanted) => (got) => test.strictEqual(got, wanted);
+  example.add(10, 5, strictEq(15));
+  example.add(-2, 7, strictEq(5));
+  example.add(65535, 1, strictEq(2 ** 16));
+  example.sub(10, 10, strictEq(0));
+  example.sub(23, 1000_000, strictEq(-999_977));
 
   test.end();
 });
@@ -80,6 +94,13 @@ metatests.test('AssemblyScript WASM (node)', async (test) => {
     test.strictEqual(res, 10);
   });
 
+  const strictEq = (wanted) => (got) => test.strictEqual(got, wanted);
+  example.add(10, 5, strictEq(15));
+  example.add(-2, 7, strictEq(5));
+  example.add(65535, 1, strictEq(2 ** 16));
+  example.sub(10, 10, strictEq(0));
+  example.sub(23, 1000_000, strictEq(-999_977));
+
   test.end();
 });
 
@@ -105,6 +126,13 @@ metatests.test('C++ WASM (node)', async (test) => {
   example.instance.exports.sub(20, 10, (res) => {
     test.strictEqual(res, 10);
   });
+
+  const strictEq = (wanted) => (got) => test.strictEqual(got, wanted);
+  example.add(10, 5, strictEq(15));
+  example.add(-2, 7, strictEq(5));
+  example.add(65535, 1, strictEq(2 ** 16));
+  example.sub(10, 10, strictEq(0));
+  example.sub(23, 1000_000, strictEq(-999_977));
 
   test.end();
 });

--- a/test/web.js
+++ b/test/web.js
@@ -52,6 +52,13 @@ metatests.test('Rust WASM (web): wasm-pack', async (test) => {
     test.strictEqual(res, 10);
   });
 
+  const strictEq = (wanted) => (got) => test.strictEqual(got, wanted);
+  example.add(10, 5, strictEq(15));
+  example.add(-2, 7, strictEq(5));
+  example.add(65535, 1, strictEq(2 ** 16));
+  example.sub(10, 10, strictEq(0));
+  example.sub(23, 1000_000, strictEq(-999_977));
+
   test.end();
 });
 
@@ -80,6 +87,13 @@ metatests.test('WAT WASM (web): wabt/wat2wasm', async (test) => {
   example.instance.exports.sub(20, 10, (res) => {
     test.strictEqual(res, 10);
   });
+
+  const strictEq = (wanted) => (got) => test.strictEqual(got, wanted);
+  example.add(10, 5, strictEq(15));
+  example.add(-2, 7, strictEq(5));
+  example.add(65535, 1, strictEq(2 ** 16));
+  example.sub(10, 10, strictEq(0));
+  example.sub(23, 1000_000, strictEq(-999_977));
 
   test.end();
 });
@@ -110,6 +124,13 @@ metatests.test('AssemblyScript WASM (web)', async (test) => {
     test.strictEqual(res, 10);
   });
 
+  const strictEq = (wanted) => (got) => test.strictEqual(got, wanted);
+  example.add(10, 5, strictEq(15));
+  example.add(-2, 7, strictEq(5));
+  example.add(65535, 1, strictEq(2 ** 16));
+  example.sub(10, 10, strictEq(0));
+  example.sub(23, 1000_000, strictEq(-999_977));
+
   test.end();
 });
 
@@ -138,6 +159,13 @@ metatests.test('C++ WASM (web)', async (test) => {
   example.instance.exports.sub(20, 10, (res) => {
     test.strictEqual(res, 10);
   });
+
+  const strictEq = (wanted) => (got) => test.strictEqual(got, wanted);
+  example.add(10, 5, strictEq(15));
+  example.add(-2, 7, strictEq(5));
+  example.add(65535, 1, strictEq(2 ** 16));
+  example.sub(10, 10, strictEq(0));
+  example.sub(23, 1000_000, strictEq(-999_977));
 
   test.end();
 });


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings; not applicable;

Opening as a separate PR
Short-cutting 'module.instance.exports.method' to 'module.method' for convenience by means of putting
the resulting wasm module object behind a proxy.